### PR TITLE
[CUBRIDQA-1093] Disable reuse_oid

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -55,6 +55,12 @@ function run_test ()
 {
   run_checkout
 
+  #CUBRIDQA-1093. disable reuse_oid 
+  cd $WORKDIR/cubrid-testtools
+  CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/sql.conf create_table_reuseoid no
+  CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no
+  cd -
+
   for t in ${TEST_SUITE//:/ }; do
     (cd $WORKDIR/cubrid-testtools && HOME=$WORKDIR CTP/bin/ctp.sh $t)
   done


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1093

Temporary modification for too many fails due to reuse_oid setting. 