### PR TITLE
[CUBRIDQA-1093] Remove the reuseoid setting of sql configure

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -57,7 +57,6 @@ function run_test ()
 
   #CUBRIDQA-1093. disable reuse_oid 
   cd $WORKDIR/cubrid-testtools
-  CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/sql.conf create_table_reuseoid no
   CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no
   cd -
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1093

The create_table_reuseoid setting keeps in case of medium by limitation however not sql.
