### PR TITLE
[CUBRIDQA-1099] The CTP branch used by dockerci is fixed as release/10.2

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -26,7 +26,7 @@ ENV PATH $CUBRID/bin:/opt/rh/sclo-git212/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH $CUBRID/lib
 ENV TEST_SUITE medium:sql
 ENV TEST_REPORT /tmp/tests
-ENV BRANCH_TESTTOOLS master
+ENV BRANCH_TESTTOOLS release/10.2
 ENV BRANCH_TESTCASES release/10.2
 
 # set timezone for test


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1099