### PR TITLE
[CUBRIDQA-1037] Changed mirror url to install package

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -2,13 +2,22 @@ FROM centos:6
 
 LABEL Description="This is a build and test environment image for CUBRID"
 
+RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo
+RUN sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=https:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo
+
+RUN yum install -y centos-release-scl
+
+RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-SCLo-scl.repo
+RUN sed -i -e "s/^# baseurl=http:\/\/mirror.centos.org/baseurl=https:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-SCLo-scl.repo
+RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+RUN sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=https:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+
 RUN set -x \
-	&& yum install -y centos-release-scl \
-	&& yum install -y --setopt=tsflags=nodocs devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-make \
-		devtoolset-8-elfutils-libelf-devel devtoolset-8-systemtap-sdt-devel \
-		ncurses-devel cmake java-1.8.0-openjdk-devel ant flex sclo-git212 wget libxslt \
-		rpm-build libtool libtool-ltdl autoconf automake \
-	&& yum clean all -y
+        && yum install -y --setopt=tsflags=nodocs devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-make \
+                devtoolset-8-elfutils-libelf-devel devtoolset-8-systemtap-sdt-devel \
+                ncurses-devel cmake java-1.8.0-openjdk-devel ant flex sclo-git212 wget libxslt \
+                rpm-build libtool libtool-ltdl autoconf automake \
+        && yum clean all -y
 
 # install bison 3 for PR #1125
 ENV BISON_VERSION 3.0.5


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1037

Can't install build package due to CentOS 6 EOL (November 30, 2020).
This has been resolved with using vault.centos.org.
