### PR TITLE
[CBRD-23949] Backport from 11.2 for the seperated cci repo

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -38,7 +38,7 @@ ENV JAVA_HOME /usr/lib/jvm/java
 ENV CUBRID $WORKDIR/CUBRID
 ENV CUBRID_DATABASES $CUBRID/databases
 ENV PATH $CUBRID/bin:/opt/rh/sclo-git212/root/usr/bin:/usr/cmake-$CMAKE_VERSION-Linux-x86_64/bin:$PATH
-ENV LD_LIBRARY_PATH $CUBRID/lib
+ENV LD_LIBRARY_PATH $CUBRID/lib:$CUBRID/cci/lib
 ENV TEST_SUITE medium:sql
 ENV TEST_REPORT /tmp/tests
 ENV BRANCH_TESTTOOLS develop

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -100,6 +100,12 @@ function report_test ()
     return 1
   fi
 
+  #In case of testing nothing due to an error like failure to load a library.
+  if [ `find $result_path -type f -name summary_info | wc -l` -eq 0 ]; then
+     echo "Nothing is tested because of an error."
+     exit 1 
+  fi
+
   failed_list=$(find $result_path -name summary_info | xargs -n1 grep -hw nok | awk -F: '{print $1}')
   if [ -z "$failed_list" ]; then
     nfailed=0


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23949

Refer to #33 