### PR TITLE
[CBRD-24775] Upgrade CMake version to 3.x

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -23,7 +23,19 @@ RUN set -x \
 ENV BISON_VERSION 3.0.5
 RUN curl -L https://ftp.gnu.org/gnu/bison/bison-$BISON_VERSION.tar.gz | tar xzvf - \
     && cd bison-$BISON_VERSION && ./configure --prefix=/usr && make all install \
-    && rm -rf bison-$BISON_VERSION
+    && rm -rf bison-$BISON_VERSION && cd ..
+
+# install cmake 3.26
+ENV CMAKE_VERSION 3.26.3
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz | tar xzvf - \
+ && yes | cp -fR cmake-$CMAKE_VERSION-linux-x86_64/* /usr
+
+# install ninja generator
+ENV NINJA_VERSION 1.11.1
+RUN source scl_source enable devtoolset-8 \
+	&& curl -L https://github.com/ninja-build/ninja/archive/refs/tags/v$NINJA_VERSION.tar.gz | tar xzvf - \
+    && cd ninja-$NINJA_VERSION && cmake -Bbuild-cmake && cmake --build build-cmake
+    && mv build-cmake/ninja /usr/bin/ninja
 
 ENV WORKDIR /home
 ENV JAVA_HOME /usr/lib/jvm/java


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24775

- Install cmake3 and ninja generator

Note that the error that occurs in RPM, CPackOptions.cmake.in should be fixed in cubrid repository.