### PR TITLE
[CUBRIDQA-1184] fix the CTP build order

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -57,13 +57,13 @@ function run_test ()
 {
   run_checkout
 
+  cd $WORKDIR/cubrid-testtools/CTP
+  ant dist
+  cd -
+
   #CUBRIDQA-1093. disable reuse_oid 
   cd $WORKDIR/cubrid-testtools
   CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no
-  cd -
-
-  cd $WORKDIR/cubrid-testtools/CTP
-  ant dist
   cd -
 
   for t in ${TEST_SUITE//:/ }; do

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -62,6 +62,10 @@ function run_test ()
   CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no
   cd -
 
+  cd $WORKDIR/cubrid-testtools/CTP
+  ant clean dist
+  cd -
+
   for t in ${TEST_SUITE//:/ }; do
     (cd $WORKDIR/cubrid-testtools && HOME=$WORKDIR CTP/bin/ctp.sh $t)
   done

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -63,7 +63,7 @@ function run_test ()
   cd -
 
   cd $WORKDIR/cubrid-testtools/CTP
-  ant clean dist
+  ant dist
   cd -
 
   for t in ${TEST_SUITE//:/ }; do


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1184

- moved the build step before running CTP/bin/ini.sh which needs the jar files made by the build