### PR TITLE
[CBRD-24475] Upgrade CMkae version to 3.x

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -L https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/c
 ENV NINJA_VERSION 1.11.1
 RUN source scl_source enable devtoolset-8 \
 	&& curl -L https://github.com/ninja-build/ninja/archive/refs/tags/v$NINJA_VERSION.tar.gz | tar xzvf - \
-    && cd ninja-$NINJA_VERSION && cmake -Bbuild-cmake && cmake --build build-cmake
+    && cd ninja-$NINJA_VERSION && cmake -Bbuild-cmake && cmake --build build-cmake \
     && mv build-cmake/ninja /usr/bin/ninja
 
 ENV WORKDIR /home

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -47,8 +47,8 @@ ENV PATH $CUBRID/bin:/opt/rh/sclo-git212/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH $CUBRID/lib:$CUBRID/cci/lib
 ENV TEST_SUITE medium:sql
 ENV TEST_REPORT /tmp/tests
-ENV BRANCH_TESTTOOLS feature/plcsql
-ENV BRANCH_TESTCASES feature/plcsql
+ENV BRANCH_TESTTOOLS develop
+ENV BRANCH_TESTCASES develop
 
 # set timezone for test
 ENV TZ Asia/Seoul

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -23,7 +23,19 @@ RUN set -x \
 ENV BISON_VERSION 3.0.5
 RUN curl -L https://ftp.gnu.org/gnu/bison/bison-$BISON_VERSION.tar.gz | tar xzvf - \
     && cd bison-$BISON_VERSION && ./configure --prefix=/usr && make all install \
-    && rm -rf bison-$BISON_VERSION
+    && rm -rf bison-$BISON_VERSION && cd ..
+
+# install cmake 3.26
+ENV CMAKE_VERSION 3.26.3
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz | tar xzvf - \
+ && yes | cp -fR cmake-$CMAKE_VERSION-linux-x86_64/* /usr
+
+# install ninja generator
+ENV NINJA_VERSION 1.11.1
+RUN source scl_source enable devtoolset-8 \
+	&& curl -L https://github.com/ninja-build/ninja/archive/refs/tags/v$NINJA_VERSION.tar.gz | tar xzvf - \
+    && cd ninja-$NINJA_VERSION && cmake -Bbuild-cmake && cmake --build build-cmake
+    && mv build-cmake/ninja /usr/bin/ninja
 
 ENV WORKDIR /home
 ENV JAVA_HOME /usr/lib/jvm/java

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -28,14 +28,16 @@ RUN curl -L https://ftp.gnu.org/gnu/bison/bison-$BISON_VERSION.tar.gz | tar xzvf
 # install cmake 3.26
 ENV CMAKE_VERSION 3.26.3
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz | tar xzvf - \
- && yes | cp -fR cmake-$CMAKE_VERSION-linux-x86_64/* /usr
+ && yes | cp -fR cmake-$CMAKE_VERSION-linux-x86_64/* /usr \
+ && rm -rf cmake-$CMAKE_VERSION-linux-x86_64
 
 # install ninja generator
 ENV NINJA_VERSION 1.11.1
 RUN source scl_source enable devtoolset-8 \
 	&& curl -L https://github.com/ninja-build/ninja/archive/refs/tags/v$NINJA_VERSION.tar.gz | tar xzvf - \
     && cd ninja-$NINJA_VERSION && cmake -Bbuild-cmake && cmake --build build-cmake \
-    && mv build-cmake/ninja /usr/bin/ninja
+    && mv build-cmake/ninja /usr/bin/ninja && cd .. \
+    && rm -rf ninja-$NINJA_VERSION
 
 ENV WORKDIR /home
 ENV JAVA_HOME /usr/lib/jvm/java

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -47,8 +47,8 @@ ENV PATH $CUBRID/bin:/opt/rh/sclo-git212/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH $CUBRID/lib:$CUBRID/cci/lib
 ENV TEST_SUITE medium:sql
 ENV TEST_REPORT /tmp/tests
-ENV BRANCH_TESTTOOLS develop
-ENV BRANCH_TESTCASES develop
+ENV BRANCH_TESTTOOLS feature/plcsql
+ENV BRANCH_TESTCASES feature/plcsql
 
 # set timezone for test
 ENV TZ Asia/Seoul

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -33,7 +33,7 @@ function run_build ()
   fi
 
   (cd $CUBRID_SRCDIR \
-    && ./build.sh -p $CUBRID $@ clean build) | tee build.log | grep -e '\[[ 0-9]\+%\]' -e ' error: ' || { tail -500 build.log; false; }
+    && ./build.sh -p $CUBRID $@ clean build) | tee build.log | grep -e '\[[ 0-9]\+%\]' -e ' error: ' -e '\[[0-9]\+\/[0-9]\+\]' || { tail -500 build.log; false; }
 
   grep "Building failed" $CUBRID_SRCDIR/build.log && exit 1 || { true; }  
 }

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -62,6 +62,10 @@ function run_test ()
   CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no
   cd -
 
+  cd $WORKDIR/cubrid-testtools/CTP
+  ant dist
+  cd -
+
   for t in ${TEST_SUITE//:/ }; do
     (cd $WORKDIR/cubrid-testtools && HOME=$WORKDIR CTP/bin/ctp.sh $t)
   done

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -57,17 +57,9 @@ function run_test ()
 {
   run_checkout
 
-  cd $WORKDIR/cubrid-testtools/CTP
-  ant dist
-  cd -
-
   #CUBRIDQA-1093. disable reuse_oid 
   cd $WORKDIR/cubrid-testtools
   CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no
-  cd -
-
-  cd $WORKDIR/cubrid-testtools/CTP
-  ant dist
   cd -
 
   for t in ${TEST_SUITE//:/ }; do

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -57,6 +57,10 @@ function run_test ()
 {
   run_checkout
 
+  cd $WORKDIR/cubrid-testtools/CTP
+  ant dist
+  cd -
+
   #CUBRIDQA-1093. disable reuse_oid 
   cd $WORKDIR/cubrid-testtools
   CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24775

For the test environemnt of PL/CSQL, upgrading CMake version is required.
The environment has been tested in the develop_buildng branch of cubridci repo and feature/plcsql branch of cubrid repo.

The commits from 3444dd8 to cacd1ec are cherry-picked from develop_buildng branch.