### PR TITLE
[CUBRIDQA-1184] utf8 file encoding for oralce linux

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -31,6 +31,9 @@ ENV TEST_REPORT /tmp/tests
 ENV BRANCH_TESTTOOLS develop
 ENV BRANCH_TESTCASES develop
 
+# Temporary
+ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8 
+
 # set timezone for test
 ENV TZ Asia/Seoul
 RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1184

### unmappable character for encoding ascii error
It fails to compile CTP on the oracle linux docker container which is running in circleci due to the system encoding. 

Fix it  urgently until a valid solution is found. 