### PR TITLE
[CUBRIDQA-1219] CTP is build by the latest commit when the ci test

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -57,8 +57,12 @@ function run_test ()
 {
   run_checkout
 
-  #CUBRIDQA-1093. disable reuse_oid 
+  
   cd $WORKDIR/cubrid-testtools
+  # build the CTP
+  ant
+
+  #CUBRIDQA-1093. disable reuse_oid
   CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no
   cd -
 


### PR DESCRIPTION
참고: http://jira.cubrid.org/browse/CUBRIDQA-1219

ci test 수행시, 반드시 ctp를 빌드한 후 테스트가 수행되도록 docker-entrypoint.sh을 수정했습니다.