### PR TITLE
[CUBRIDQA-1268] use CC & CXX instead of CMAKE_CCACHE_LAUNCHER

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -64,6 +64,7 @@ RUN echo 'ZONE="Asia/Seoul' > /etc/sysconfig/clock
 RUN localedef -f UTF-8 -i ko_KR ko_KR.utf8
 RUN localedef -f EUC-KR -i ko_KR ko_KR.euckr
 
+# ccache configuration
 ENV CC="ccache gcc"
 ENV CXX="ccache g++"
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -64,9 +64,8 @@ RUN echo 'ZONE="Asia/Seoul' > /etc/sysconfig/clock
 RUN localedef -f UTF-8 -i ko_KR ko_KR.utf8
 RUN localedef -f EUC-KR -i ko_KR ko_KR.euckr
 
-# ccache configuration
-ENV CMAKE_C_COMPILER_LAUNCHER=ccache
-ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
+ENV CC="ccache gcc"
+ENV CXX="ccache g++"
 
 COPY docker-entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
ENV CMAKE_C_COMPILER_LAUNCHER=ccache
ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache

중복으로 설정된 이 두 환경변수들을 지우고 CC, CXX로 대체합니다.

---

https://github.com/CUBRID/cubrid/blob/develop/.circleci/config.yml#L212

큐브리드는 이미 circleci에서 위와 같이 CC 환경 변수들을 빌드시 설정해주고 있습니다.

이때 CMake Launcher 를 ccache로 설정할 경우, 빌드 속도가 느려집니다.

이는 ccache가 중복으로 적용이 되어서인 것으로 추정하고 있습니다.