### PR TITLE
[CUBRIDQA-1268] Add ccache for centos6 envrionment.

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -65,8 +65,8 @@ RUN localedef -f UTF-8 -i ko_KR ko_KR.utf8
 RUN localedef -f EUC-KR -i ko_KR ko_KR.euckr
 
 # ccache configuration
-ENV CMAKE_C_COMPILER_LAUNCHER=ccache
-ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
+ENV CC="ccache gcc"
+ENV CXX="ccache g++"
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:6
 
 LABEL Description="This is a build and test environment image for CUBRID"
 
@@ -20,7 +20,8 @@ RUN set -x \
                 ncurses-devel cmake java-1.8.0-openjdk-devel ant flex sclo-git212 wget libxslt \
                 rpm-build libtool libtool-ltdl autoconf automake \
                 make git which ccache \
-        && yum clean all -y
+        && yum clean all -y \
+        && rm -rf /var/cache/yum
 
 # install bison 3 for PR #1125
 ENV BISON_VERSION 3.0.5

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -19,7 +19,7 @@ RUN set -x \
                 devtoolset-8-elfutils-libelf-devel devtoolset-8-systemtap-sdt-devel \
                 ncurses-devel cmake java-1.8.0-openjdk-devel ant flex sclo-git212 wget libxslt \
                 rpm-build libtool libtool-ltdl autoconf automake \
-                make git which ccache \
+                which ccache \
         && yum clean all -y \
         && rm -rf /var/cache/yum
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6
+FROM centos:7
 
 LABEL Description="This is a build and test environment image for CUBRID"
 
@@ -13,10 +13,13 @@ RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\
 RUN sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=https:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 
 RUN set -x \
-        && yum install -y --setopt=tsflags=nodocs devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-make \
+        && yum install -y epel-release \
+        && yum install -y --setopt=tsflags=nodocs \
+                devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-make \
                 devtoolset-8-elfutils-libelf-devel devtoolset-8-systemtap-sdt-devel \
                 ncurses-devel cmake java-1.8.0-openjdk-devel ant flex sclo-git212 wget libxslt \
                 rpm-build libtool libtool-ltdl autoconf automake \
+                make git which ccache \
         && yum clean all -y
 
 # install bison 3 for PR #1125
@@ -60,6 +63,10 @@ RUN echo 'ZONE="Asia/Seoul' > /etc/sysconfig/clock
 # install multi-language locale for unicode test
 RUN localedef -f UTF-8 -i ko_KR ko_KR.utf8
 RUN localedef -f EUC-KR -i ko_KR ko_KR.euckr
+
+# ccache configuration
+ENV CMAKE_C_COMPILER_LAUNCHER=ccache
+ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -58,7 +58,11 @@ function run_dist ()
 
 function run_test ()
 {
-  run_checkout
+  if [ -z "$CIRCLECI" ]; then
+    run_checkout
+  else
+    echo "[info] Skipping run_checkout in run_test on CircleCI"
+  fi
 
   #CUBRIDQA-1093. disable reuse_oid 
   cd $WORKDIR/cubrid-testtools

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -13,7 +13,10 @@ function run_checkout ()
   if [ ! -d $WORKDIR/cubrid-testcases ]; then
     git clone -q --depth 1 --branch $BRANCH_TESTCASES https://github.com/CUBRID/cubrid-testcases $WORKDIR/cubrid-testcases
   elif [ -d $WORKDIR/cubrid-testcases/.git ]; then
-    (cd $WORKDIR/cubrid-testcases && git clean -df)
+    cd $WORKDIR/cubrid-testcases && \
+    git fetch -q --depth 1 origin $BRANCH_TESTCASES && \
+    git reset --hard FETCH_HEAD && \
+    git clean -df
   else
     echo "Cannot find .git from $WORKDIR/cubrid-testcases directory!"
     return 1


### PR DESCRIPTION
jenkins 빌드이미지와 circleci 의 이미지를 통일하기 위해 centos6 적용.
centos6 에서 사용가능한 ccache 3.1.6 을 적용.
