### PR TITLE
[CUBRIDQA-1279] Add git options.

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -26,7 +26,7 @@ clone_repository() {
   
   debug "clone_repository $repo $branch $url" "$LINENO"
   if [ ! -d "$WORKDIR/$repo" ]; then
-    sudo -E -u "$USER" bash -c "git clone -q --depth 1 --branch $branch $url $WORKDIR/$repo"
+    sudo -E -u "$USER" bash -c "git -c fetch.parallel=0 -c core.compression=0 clone -q --depth 1 --branch $branch --single-branch --no-tags $url $WORKDIR/$repo"
   elif [ -d "$WORKDIR/$repo" ]; then
     sudo -E -u "$USER" bash -c "cd $WORKDIR/$repo && git fetch --depth 1 origin $branch && git reset --hard origin/$branch && git clean -df"
   else
@@ -58,10 +58,10 @@ run_test() {
   set +e
   report_test $TEST_REPORT $feedback_file
   ret=$?
-  set -e
-  if [ $ret -gt 0 ]; then
-    run_manual_test_result $TEST_REPORT $BASELINE
-  fi
+  # set -e
+  # if [ $ret -gt 0 ]; then
+  #   run_manual_test_result $TEST_REPORT $BASELINE
+  # fi
 
   debug "run_test() exit $ret" "$LINENO"
   exit $ret


### PR DESCRIPTION
Tried to store testcases in Persistent Volume on K8s infra. 
However, the CircleCI helm chart is written as a replica set, so it cannot claim the same Persistent volume for each pod.

Therefore, to accelerate git repo cloning speed, 
- Add git options for faster cloning

Tested in docker container.
before ) git clone -q --depth 1 --branch
real    6m28.608s

after ) git -c fetch.parallel=0 -c core.compression=0 clone -q --depth 1 --branch $branch --single-branch --no-tags 
real    2m47.244s

- Comment out the DB connecting function for faster job execution
IP addresses must be assigned as internal addresses, caused by using Self self-hosted runner.
