### PR TITLE
[CUBRIDQA-1243] modify retry log parsing.

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -51,12 +51,11 @@ run_checkout() {
 # Function to run tests
 run_test() {
   debug "run_test()" "$LINENO"
-  local feedback_file="$CTP_HOME/result/shell/current_runtime_logs/feedback.log"
   
   ( cd $CTP_HOME && HOME=$WORKDIR ./bin/ctp.sh shell -c $CTP_HOME/conf/shell_ci.conf )
   
   set +e
-  report_test $TEST_REPORT $feedback_file
+  report_test $TEST_REPORT
   ret=$?
   # set -e
   # if [ $ret -gt 0 ]; then
@@ -73,7 +72,8 @@ report_test() {
   local xml_output=$1
   local summary_xml=$xml_output/summary.xml
   local junit_xml=$xml_output/test-${TEST_SUITE}.xml
-  local feedback_file=$2
+  local feedback_file="$CTP_HOME/result/shell/current_runtime_logs/feedback.log"
+  local snapshot_file="$CTP_HOME/result/shell/current_runtime_logs/main_snapshot.properties"
 
   # Validate input
   if [ ! -f "$feedback_file" ]; then
@@ -81,12 +81,19 @@ report_test() {
     return 1
   fi
 
+  local retry_num
+  if [ -f "$snapshot_file" ]; then
+    retry_num=$(awk -F= '/^testcase_retry_num=/ {print $2}' "$snapshot_file")
+  else
+    retry_num=0
+  fi
+
   # Initialize summary XML file with header
   mkdir -p "$xml_output"
   cat > "$summary_xml" << EOF
 <results>
 EOF
-awk '
+awk -v MAX_RETRY="$retry_num" '
   # SKIP_BY_MACRO pattern
   /\[SKIP_BY_MACRO\].*cubrid-testcases-private-ex\/shell\/[^ ]+\.sh/ {
     match($0, /cubrid-testcases-private-ex\/shell\/[^ ]+\.sh/);
@@ -128,6 +135,11 @@ awk '
     match($0, /cubrid-testcases-private-ex\/shell\/[^ ]+\.sh/);
     nok_test = substr($0, RSTART, RLENGTH);
     sub("cubrid-testcases-private-ex/", "", nok_test);
+    if (match($0, /TRY-> = [0-9]+/)) {
+      try_count = substr($0, RSTART+7, RLENGTH-7);
+    } else {
+      try_count = 0;
+    }
     nok_pending = 1;
     error_text = $0 "\n";
     next;
@@ -144,7 +156,9 @@ awk '
     match($0, /time=[0-9]+/);
     time = substr($0, RSTART+5, RLENGTH-5);
     error_text = error_text $0 "\n";
-    print "  <scenario>\n     <case>" nok_test "</case>\n     <elapsetime>" time "</elapsetime>\n     <result>fail</result>\n     <failure_message>Test failed</failure_message>\n     <error_content><![CDATA[" error_text "]]></error_content>\n  </scenario>";
+    if (try_count == MAX_RETRY) {
+      print "  <scenario>\n     <case>" nok_test "</case>\n     <elapsetime>" time "</elapsetime>\n     <result>fail</result>\n     <failure_message>Test failed</failure_message>\n     <error_content><![CDATA[" error_text "]]></error_content>\n  </scenario>";
+    }
     nok_pending = 0;
     next;
   }

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -82,9 +82,8 @@ report_test() {
   fi
 
   local retry_num
-  if [ -f "$snapshot_file" ]; then
-    retry_num=$(awk -F= '/^testcase_retry_num=/ {print $2}' "$snapshot_file")
-  else
+  retry_num=$(awk -F= '/^testcase_retry_num=/ {print $2}' "$snapshot_file")
+  if [ -z "$retry_num" ]; then
     retry_num=0
   fi
 


### PR DESCRIPTION
https://github.com/CUBRID/cubrid-testtools/pull/715
shell_ci.conf 의 retry num 변경이 circleci tests 탭에 중복된 로그를 남기므로 
이를 방직하기위해 마지막 시도 실패만 남도록 수정.