### PR TITLE
Revert "[CUBRIDQA-1243] modify retry log parsing."

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -51,11 +51,12 @@ run_checkout() {
 # Function to run tests
 run_test() {
   debug "run_test()" "$LINENO"
+  local feedback_file="$CTP_HOME/result/shell/current_runtime_logs/feedback.log"
   
   ( cd $CTP_HOME && HOME=$WORKDIR ./bin/ctp.sh shell -c $CTP_HOME/conf/shell_ci.conf )
   
   set +e
-  report_test $TEST_REPORT
+  report_test $TEST_REPORT $feedback_file
   ret=$?
   # set -e
   # if [ $ret -gt 0 ]; then
@@ -72,8 +73,7 @@ report_test() {
   local xml_output=$1
   local summary_xml=$xml_output/summary.xml
   local junit_xml=$xml_output/test-${TEST_SUITE}.xml
-  local feedback_file="$CTP_HOME/result/shell/current_runtime_logs/feedback.log"
-  local snapshot_file="$CTP_HOME/result/shell/current_runtime_logs/main_snapshot.properties"
+  local feedback_file=$2
 
   # Validate input
   if [ ! -f "$feedback_file" ]; then
@@ -81,18 +81,12 @@ report_test() {
     return 1
   fi
 
-  local retry_num
-  retry_num=$(awk -F= '/^testcase_retry_num=/ {print $2}' "$snapshot_file")
-  if [ -z "$retry_num" ]; then
-    retry_num=0
-  fi
-
   # Initialize summary XML file with header
   mkdir -p "$xml_output"
   cat > "$summary_xml" << EOF
 <results>
 EOF
-awk -v MAX_RETRY="$retry_num" '
+awk '
   # SKIP_BY_MACRO pattern
   /\[SKIP_BY_MACRO\].*cubrid-testcases-private-ex\/shell\/[^ ]+\.sh/ {
     match($0, /cubrid-testcases-private-ex\/shell\/[^ ]+\.sh/);
@@ -134,11 +128,6 @@ awk -v MAX_RETRY="$retry_num" '
     match($0, /cubrid-testcases-private-ex\/shell\/[^ ]+\.sh/);
     nok_test = substr($0, RSTART, RLENGTH);
     sub("cubrid-testcases-private-ex/", "", nok_test);
-    if (match($0, /TRY-> = [0-9]+/)) {
-      try_count = substr($0, RSTART+7, RLENGTH-7);
-    } else {
-      try_count = 0;
-    }
     nok_pending = 1;
     error_text = $0 "\n";
     next;
@@ -155,9 +144,7 @@ awk -v MAX_RETRY="$retry_num" '
     match($0, /time=[0-9]+/);
     time = substr($0, RSTART+5, RLENGTH-5);
     error_text = error_text $0 "\n";
-    if (try_count == MAX_RETRY) {
-      print "  <scenario>\n     <case>" nok_test "</case>\n     <elapsetime>" time "</elapsetime>\n     <result>fail</result>\n     <failure_message>Test failed</failure_message>\n     <error_content><![CDATA[" error_text "]]></error_content>\n  </scenario>";
-    }
+    print "  <scenario>\n     <case>" nok_test "</case>\n     <elapsetime>" time "</elapsetime>\n     <result>fail</result>\n     <failure_message>Test failed</failure_message>\n     <error_content><![CDATA[" error_text "]]></error_content>\n  </scenario>";
     nok_pending = 0;
     next;
   }


### PR DESCRIPTION
Reverts CUBRID/cubridci#75

내부에서 파싱을 위해 사용하는 awk 스크립트 내에서 <. [.] 과 같은 문자열을 파싱할 수 없음.
해당 문자열은 테스트 수행 결과 중 diff 결과를 출력하는데 사용하고 이를 xml CDATA 형식에 담아 출력해야하는데 파싱과정에서 CDATA 블록을 닫는것으로 인식하는 문제가 있음.

awk 를 사용하지 않고 bash 나 다른 방식으로 feedback.log 파일을 파싱하도록 변경 필요.

변경전 까지 circleci TESTS 탭 결과에 retry 로인한 실패로그가 중복으로 출력 될 수 있음.