### PR TITLE
[CUBRIDQA-1287] add missing environmental variable for locale

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -62,8 +62,10 @@ RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
 RUN echo 'ZONE="Asia/Seoul' > /etc/sysconfig/clock
 
 # install multi-language locale for unicode test
-RUN localedef -f UTF-8 -i ko_KR ko_KR.utf8
-RUN localedef -f EUC-KR -i ko_KR ko_KR.euckr
+RUN localedef -f UTF-8 -i ko_KR ko_KR.UTF-8 \
+ && localedef -f EUC-KR -i ko_KR ko_KR.EUC-KR \
+ && localedef -f UTF-8 -i en_US en_US.UTF-8
+ENV LC_ALL=en_US
 
 # ccache configuration
 ENV CC="ccache gcc"


### PR DESCRIPTION
regression test 환경과 일치시키기위해 LC_ALL=en_US 를 설정함.
refer to : https://github.com/CUBRID/cubrid-testtools/blob/develop/doc/sql_guide.md#21-sql-test