### PR TITLE
fix: reset FETCH_HEAD

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -31,7 +31,7 @@ clone_repository() {
   if [ ! -d "$WORKDIR/$repo" ]; then
     sudo -E -u "$USER" bash -c "git -c fetch.parallel=0 -c core.compression=9 clone -q --depth 1 --branch $branch --single-branch --no-tags $url $WORKDIR/$repo"
   elif [ -d "$WORKDIR/$repo" ]; then
-    sudo -E -u "$USER" bash -c "cd $WORKDIR/$repo && git fetch --depth 1 origin $branch && git reset --hard origin/$branch && git clean -df"
+    sudo -E -u "$USER" bash -c "cd $WORKDIR/$repo && git fetch --depth 1 origin $branch && git reset --hard FETCH_HEAD && git clean -df"
   else
     debug "Cannot find .git from $WORKDIR/$repo directory!" "$LINENO"
     exit 1


### PR DESCRIPTION
### Purpose
현재 cubrid-testcase-private-ex 폴더가 존재할 때, 최신 커밋을 fetch 해오지만 git 의 HEAD 를 최신 fetch로 이동시키지 않고 있습니다.
이러한 문제를 해결합니다.

<img width="1747" height="348" alt="image" src="https://github.com/user-attachments/assets/52d84d36-e26a-42be-ba87-b9ceae058875" />
