### PR TITLE
[CUBRIDQA-1301] add core size 10mb for call stack trace.

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf install -y epel-release && \
     dnf install -y --setopt=install_weak_deps=False \
     # Build and Development tools
     gcc-c++ \
+    gdb \
     git \
     # System utilities
     vim-minimal \

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -14,6 +14,9 @@ configure() {
 
   sudo /usr/sbin/sshd
 
+  ulimit -c 10485760
+  debug "core file size (10mb): `ulimit -c`" "$LINENO"
+
   debug "`env`" "$LINENO"
   git config --global url."https://x-access-token:${GHI_TOKEN}@github.com/".insteadof https://github.com/
   debug "configure done. $(git config -l)" "$LINENO"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1301

call stack trace 정보만 남도록 코어사이즈를 10mb 로 제한.
CTP 의 core analyzer 동작에 gdb 필요하여 추가.
