### PR TITLE
[CUBRIDQA-1287] add missing environmental variable for locale

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -47,6 +47,12 @@ RUN ssh-keygen -A && \
     ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
     echo "Asia/Seoul" > /etc/timezone
 
+# install multi-language locale for unicode test
+RUN localedef -f UTF-8 -i ko_KR ko_KR.UTF-8 \
+ && localedef -f EUC-KR -i ko_KR ko_KR.EUC-KR \
+ && localedef -f UTF-8 -i en_US en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
 #circleci env
 ENV TEST_REPORT=/tmp/tests
 ENV BASELINE none


### PR DESCRIPTION
reflect locale setting for shell test.
refer to : https://github.com/CUBRID/cubrid-testtools/blob/develop/doc/sql_guide.md#21-sql-test , #81 
