### PR TITLE
[CUBRIDQA-1335] upgrade jdk version

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -17,11 +17,16 @@ RUN set -x \
         && yum install -y --setopt=tsflags=nodocs \
                 devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-make \
                 devtoolset-8-elfutils-libelf-devel devtoolset-8-systemtap-sdt-devel \
-                ncurses-devel cmake java-1.8.0-openjdk-devel ant flex sclo-git212 wget libxslt \
+                ncurses-devel cmake ant flex sclo-git212 wget libxslt \
                 rpm-build libtool libtool-ltdl autoconf automake \
                 which ccache \
         && yum clean all -y \
         && rm -rf /var/cache/yum
+
+# install Adoptium Temurin JDK 8
+ENV JDK_URL="https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u442-b06/OpenJDK8U-jdk_x64_linux_hotspot_8u442b06.tar.gz"
+RUN curl -L $JDK_URL | tar xzvf - -C /opt \
+    && ln -s /opt/jdk8u442-b06 /opt/jdk8
 
 # install bison 3 for PR #1125
 ENV BISON_VERSION 3.0.5
@@ -44,7 +49,7 @@ RUN source scl_source enable devtoolset-8 \
     && rm -rf ninja-$NINJA_VERSION
 
 ENV WORKDIR /home
-ENV JAVA_HOME /usr/lib/jvm/java
+ENV JAVA_HOME /opt/jdk8
 
 # CUBRID envronment variables
 ENV CUBRID $WORKDIR/CUBRID


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1335

Java 가 SSL 연결을 시도할 때 “서버가 제시한 인증서 체인을 신뢰할 수 있는 루트CA까지 연결할 수 없음”을 의미한다. 즉 JVM의 truststore(신뢰 저장소)에 해당 서버 SSL 인증서 또는 이를 발급한 CA 인증서가 없어서 발생함.

이를 해결하기위해 java build 버전을 업그레이드 한다. 
base os 변경이 불가하므로 pl engine 과 동일한 temurin 의 openjdk 를 사용한다. 

as-is
openjdk version "1.8.0_275"
OpenJDK Runtime Environment (build 1.8.0_275-b01)

to-be
openjdk version "1.8.0_442"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_442-b06)