### PR TITLE
[CUBRIDQA-1349] add python2, python3, libstdc++-static

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -10,7 +10,8 @@ RUN set -x \
         && dnf install -y epel-release \
         && dnf install -y --setopt=tsflags=nodocs \
                 gcc gcc-c++ make \
-                elfutils-libelf-devel systemtap-sdt-devel \
+                python2-devel python3-devel\
+                elfutils-libelf-devel systemtap-sdt-devel libstdc++-static\
                 ncurses-devel ant flex git wget libxslt \
                 rpm-build libtool libtool-ltdl autoconf automake \
                 which ccache \


### PR DESCRIPTION
### Implementation

- **`python2-devel`**:  
  CUBRID 유틸 스크립트 일부가 `python2` 전제로 작성되어 있고, shebang을 `python2`로 명시했으므로 Python 2 환경/빌드 지원을 위해 필요하다.

- **`python3-devel`**:  
  Rocky Linux 8 RPM 빌드 스크립트(`brp-python*`, `brp-mangle-shebangs`)가 Python 3 환경을 사용하므로, 빌드 단계에서 Python 3 관련 스크립트 실행을 보장하기 위해 필요하다.

- **`libstdc++-static`**:  
  빌드 중 `/usr/bin/ld: cannot find -lstdc++` 링크 에러가 발생했으며, 정적 `libstdc++`(`libstdc++.a`)를 제공하는 패키지가 `libstdc++-static`이기 때문에 이를 설치해 링크 에러를 해결했다.