### PR TITLE
[CUBRIDQA-1380] split test image: rocky8 sql/medium runtime

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -56,7 +56,7 @@ ENV PATH=$CUBRID/bin:/usr/sbin:$PATH
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
-RUN chmod 777 $WORKDIR && chmod 777 /entrypoint.sh
+RUN chmod 777 $WORKDIR && chmod 755 /entrypoint.sh
 
 WORKDIR $WORKDIR
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,85 +1,63 @@
-FROM centos:6
+FROM rockylinux/rockylinux:8.10
 
-LABEL Description="This is a build and test environment image for CUBRID"
+LABEL Description="CUBRID SQL/Medium test runtime image (rocky8). Build is provided externally; this image only runs CTP sql/medium suites."
 
-RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo
-RUN sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=https:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-Base.repo
+# Test-runtime dependencies only. No build toolchain.
+RUN dnf install -y epel-release && \
+    dnf install -y --setopt=install_weak_deps=False \
+        gcc-c++ gdb git \
+        vim-minimal lsof procps-ng file diffutils which csh \
+        glibc-locale-source glibc-langpack-en glibc-langpack-ko \
+        net-tools telnet wget \
+        sudo openssh-server openssh-clients \
+        java-1.8.0-openjdk-devel \
+        libxslt dos2unix lcov bc jq expect && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf/* /var/tmp/* /tmp/*
 
-RUN yum install -y centos-release-scl
+# SSH + bookkeeping dirs (CTP/test infra expectations)
+RUN ssh-keygen -A && \
+    sed -i 's/^account.*pam_nologin.so/#&/' /etc/pam.d/sshd && \
+    mkdir -p /var/run/sshd /home/do_not_delete_core /home/ERROR_BACKUP && \
+    ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
+    echo "Asia/Seoul" > /etc/timezone
 
-RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-SCLo-scl.repo
-RUN sed -i -e "s/^# baseurl=http:\/\/mirror.centos.org/baseurl=https:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-SCLo-scl.repo
-RUN sed -i -e "s/^mirrorlist=http:\/\/mirrorlist.centos.org/#mirrorlist=http:\/\/mirrorlist.centos.org/g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-RUN sed -i -e "s/^#baseurl=http:\/\/mirror.centos.org/baseurl=https:\/\/vault.centos.org/g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+RUN localedef -f UTF-8 -i ko_KR ko_KR.UTF-8 && \
+    localedef -f EUC-KR -i ko_KR ko_KR.EUC-KR && \
+    localedef -f UTF-8 -i en_US en_US.UTF-8
 
-RUN set -x \
-        && yum install -y epel-release \
-        && yum install -y --setopt=tsflags=nodocs \
-                devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-make \
-                devtoolset-8-elfutils-libelf-devel devtoolset-8-systemtap-sdt-devel \
-                ncurses-devel cmake ant flex sclo-git212 wget libxslt \
-                rpm-build libtool libtool-ltdl autoconf automake \
-                which ccache \
-        && yum clean all -y \
-        && rm -rf /var/cache/yum
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV TZ=Asia/Seoul
 
-# install Adoptium Temurin JDK 8
-ENV JDK_URL="https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u442-b06/OpenJDK8U-jdk_x64_linux_hotspot_8u442b06.tar.gz"
-RUN curl -L $JDK_URL | tar xzvf - -C /opt \
-    && ln -s /opt/jdk8u442-b06 /opt/jdk8
+# CircleCI / runtime env
+ENV WORKDIR=/home
+ENV USER=root
+ENV TEST_REPORT=/tmp/tests
+ENV TEST_SUITE=medium:sql
+ENV BRANCH_TESTTOOLS=develop
+ENV BRANCH_TESTCASES=develop
 
-# install bison 3 for PR #1125
-ENV BISON_VERSION 3.0.5
-RUN curl -L https://ftp.gnu.org/gnu/bison/bison-$BISON_VERSION.tar.gz | tar xzvf - \
-    && cd bison-$BISON_VERSION && ./configure --prefix=/usr && make all install \
-    && rm -rf bison-$BISON_VERSION && cd ..
+# CTP env
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0
+ENV CTP_BRANCH_NAME=$BRANCH_TESTTOOLS
+ENV CTP_SKIP_UPDATE=0
+ENV CTP_HOME=$WORKDIR/cubrid-testtools/CTP
+ENV init_path=$CTP_HOME/shell/init_path
+ENV PATH=$CTP_HOME/bin:$CTP_HOME/common/script:$PATH
 
-# install cmake 3.26
-ENV CMAKE_VERSION 3.26.3
-RUN curl -L https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz | tar xzvf - \
- && yes | cp -fR cmake-$CMAKE_VERSION-linux-x86_64/* /usr \
- && rm -rf cmake-$CMAKE_VERSION-linux-x86_64
-
-# install ninja generator
-ENV NINJA_VERSION 1.11.1
-RUN source scl_source enable devtoolset-8 \
-	&& curl -L https://github.com/ninja-build/ninja/archive/refs/tags/v$NINJA_VERSION.tar.gz | tar xzvf - \
-    && cd ninja-$NINJA_VERSION && cmake -Bbuild-cmake && cmake --build build-cmake \
-    && mv build-cmake/ninja /usr/bin/ninja && cd .. \
-    && rm -rf ninja-$NINJA_VERSION
-
-ENV WORKDIR /home
-ENV JAVA_HOME /opt/jdk8
-
-# CUBRID envronment variables
-ENV CUBRID $WORKDIR/CUBRID
-ENV CUBRID_DATABASES $CUBRID/databases
-ENV PATH $CUBRID/bin:/opt/rh/sclo-git212/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH $CUBRID/lib:$CUBRID/cci/lib
-ENV TEST_SUITE medium:sql
-ENV TEST_REPORT /tmp/tests
-ENV BRANCH_TESTTOOLS develop
-ENV BRANCH_TESTCASES develop
-
-# set timezone for test
-ENV TZ Asia/Seoul
-RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
-RUN echo 'ZONE="Asia/Seoul' > /etc/sysconfig/clock
-
-# install multi-language locale for unicode test
-RUN localedef -f UTF-8 -i ko_KR ko_KR.UTF-8 \
- && localedef -f EUC-KR -i ko_KR ko_KR.EUC-KR \
- && localedef -f UTF-8 -i en_US en_US.UTF-8
-ENV LC_ALL=en_US
-
-# ccache configuration
-ENV CC="ccache gcc"
-ENV CXX="ccache g++"
+# CUBRID env (cubrid_rel etc. resolve only after run_install or pre-mounted /home/CUBRID)
+ENV CUBRID=$WORKDIR/CUBRID
+ENV CUBRID_DATABASES=$CUBRID/databases
+ENV LD_LIBRARY_PATH=$CUBRID/lib:$CUBRID/cci/lib:$LD_LIBRARY_PATH
+ENV SHLIB_PATH=$LD_LIBRARY_PATH
+ENV LIBPATH=$LD_LIBRARY_PATH
+ENV PATH=$CUBRID/bin:/usr/sbin:$PATH
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
-RUN chmod 775 /entrypoint.sh
-RUN chmod 777 $WORKDIR
+RUN chmod 777 $WORKDIR && chmod 777 /entrypoint.sh
+
 WORKDIR $WORKDIR
 
-ENTRYPOINT ["scl", "enable", "devtoolset-8", "--", "/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -5,10 +5,10 @@ function run_checkout ()
   if [ ! -d $WORKDIR/cubrid-testtools ]; then
     git clone -q --depth 1 --branch $BRANCH_TESTTOOLS https://github.com/CUBRID/cubrid-testtools $WORKDIR/cubrid-testtools
   elif [ -d $WORKDIR/cubrid-testtools/.git ]; then
-    cd $WORKDIR/cubrid-testtools && \
-    git fetch -q --depth 1 origin $BRANCH_TESTTOOLS && \
-    git reset --hard FETCH_HEAD && \
-    git clean -df
+    (cd $WORKDIR/cubrid-testtools && \
+     git fetch -q --depth 1 origin $BRANCH_TESTTOOLS && \
+     git reset --hard FETCH_HEAD && \
+     git clean -df)
   else
     echo "Cannot find .git from $WORKDIR/cubrid-testtools directory!"
     return 1
@@ -16,10 +16,10 @@ function run_checkout ()
   if [ ! -d $WORKDIR/cubrid-testcases ]; then
     git clone -q --depth 1 --branch $BRANCH_TESTCASES https://github.com/CUBRID/cubrid-testcases $WORKDIR/cubrid-testcases
   elif [ -d $WORKDIR/cubrid-testcases/.git ]; then
-    cd $WORKDIR/cubrid-testcases && \
-    git fetch -q --depth 1 origin $BRANCH_TESTCASES && \
-    git reset --hard FETCH_HEAD && \
-    git clean -df
+    (cd $WORKDIR/cubrid-testcases && \
+     git fetch -q --depth 1 origin $BRANCH_TESTCASES && \
+     git reset --hard FETCH_HEAD && \
+     git clean -df)
   else
     echo "Cannot find .git from $WORKDIR/cubrid-testcases directory!"
     return 1

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -5,7 +5,10 @@ function run_checkout ()
   if [ ! -d $WORKDIR/cubrid-testtools ]; then
     git clone -q --depth 1 --branch $BRANCH_TESTTOOLS https://github.com/CUBRID/cubrid-testtools $WORKDIR/cubrid-testtools
   elif [ -d $WORKDIR/cubrid-testtools/.git ]; then
-    (cd $WORKDIR/cubrid-testtools && git clean -df)
+    cd $WORKDIR/cubrid-testtools && \
+    git fetch -q --depth 1 origin $BRANCH_TESTTOOLS && \
+    git reset --hard FETCH_HEAD && \
+    git clean -df
   else
     echo "Cannot find .git from $WORKDIR/cubrid-testtools directory!"
     return 1
@@ -21,39 +24,6 @@ function run_checkout ()
     echo "Cannot find .git from $WORKDIR/cubrid-testcases directory!"
     return 1
   fi
-
-}
-
-function run_build ()
-{
-  if [ -f ./build.sh ]; then
-    CUBRID_SRCDIR=.
-  elif [ -f cubrid/build.sh ]; then
-    CUBRID_SRCDIR=cubrid
-  else
-    echo "Cannot find CUBRID source directory!"
-    return 1
-  fi
-
-  (cd $CUBRID_SRCDIR \
-    && ./build.sh -p $CUBRID $@ clean build) | tee build.log | grep -e '\[[ 0-9]\+%\]' -e ' error: ' -e '\[[0-9]\+\/[0-9]\+\]' || { tail -500 build.log; false; }
-
-  grep "Building failed" $CUBRID_SRCDIR/build.log && exit 1 || { true; }  
-}
-
-function run_dist ()
-{
-  if [ -f ./build.sh ]; then
-    CUBRID_SRCDIR=.
-  elif [ -f cubrid/build.sh ]; then
-    CUBRID_SRCDIR=cubrid
-  else
-    echo "Cannot find CUBRID source directory!"
-    return 1
-  fi
-
-  (cd $CUBRID_SRCDIR \
-    && ./build.sh -p $CUBRID $@ dist) | tee dist.log
 }
 
 function run_test ()
@@ -64,7 +34,12 @@ function run_test ()
     echo "[info] Skipping run_checkout in run_test on CircleCI"
   fi
 
-  #CUBRIDQA-1093. disable reuse_oid 
+  if [ ! -x "$CUBRID/bin/cubrid_rel" ]; then
+    echo "[error] CUBRID is not installed at $CUBRID. Install before invoking 'test'."
+    exit 1
+  fi
+
+  #CUBRIDQA-1093. disable reuse_oid
   cd $WORKDIR/cubrid-testtools
   CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no
   cd -
@@ -110,7 +85,7 @@ function report_test ()
   #In case of testing nothing due to an error like failure to load a library.
   if [ `find $result_path -type f -name summary_info | wc -l` -eq 0 ]; then
      echo "Nothing is tested because of an error."
-     exit 1 
+     exit 1
   fi
 
 
@@ -206,51 +181,16 @@ _EOL
   fi
 }
 
-function get_jenkins ()
-{
-  if [ -z "$JENKINS_URL" ]; then
-    while [ $# -gt 0 ]; do
-      case "$1" in
-        -url)
-          JENKINS_URL="$2"; break ;;
-      esac
-      shift
-    done
-  fi
-  if [ -z "$JENKINS_URL" ]; then
-    echo "Cannot find jenkins url from arguments"
-    return 1
-  fi
-  curl --create-dirs -sSLo jenkins/slave.jar $JENKINS_URL/jnlpJars/slave.jar
-}
-
-function run_default ()
-{
-  run_build && run_test
-}
-
 case "$1" in
   "")
-    set -- run_default
+    echo "Usage: /entrypoint.sh {checkout|test} | <command>"
+    exit 1
     ;;
   checkout)
     set -- run_checkout
     ;;
-  build)
-    shift
-    set -- run_build "$@"
-    ;;
-  dist)
-    shift
-    set -- run_dist "$@"
-    ;;
   test)
     set -- run_test
-    ;;
-  jenkins-slave)
-    shift
-    get_jenkins "$@"
-    set -- java $JAVA_OPTS -cp jenkins/slave.jar hudson.remoting.jnlp.Main -headless "$@"
     ;;
 esac
 

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -le
+#!/bin/bash -e
 
 function run_checkout ()
 {
@@ -43,7 +43,7 @@ function run_test ()
     case "$t" in
       medium)
         # CUBRIDQA-1093/CUBRID 11.x: medium_dev.conf has create_table_reuseoid=no baked in.
-        (cd $WORKDIR/cubrid-testtools && HOME=$WORKDIR CTP/bin/ctp.sh medium -c $CTP_HOME/conf/medium_dev.conf)
+        (cd $WORKDIR/cubrid-testtools && HOME=$WORKDIR CTP/bin/ctp.sh medium -c CTP/conf/medium_dev.conf)
         ;;
       *)
         (cd $WORKDIR/cubrid-testtools && HOME=$WORKDIR CTP/bin/ctp.sh $t)

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -39,13 +39,16 @@ function run_test ()
     exit 1
   fi
 
-  #CUBRIDQA-1093. disable reuse_oid
-  cd $WORKDIR/cubrid-testtools
-  CTP/bin/ini.sh -s sql/cubrid.conf CTP/conf/medium.conf create_table_reuseoid no
-  cd -
-
   for t in ${TEST_SUITE//:/ }; do
-    (cd $WORKDIR/cubrid-testtools && HOME=$WORKDIR CTP/bin/ctp.sh $t)
+    case "$t" in
+      medium)
+        # CUBRIDQA-1093/CUBRID 11.x: medium_dev.conf has create_table_reuseoid=no baked in.
+        (cd $WORKDIR/cubrid-testtools && HOME=$WORKDIR CTP/bin/ctp.sh medium -c $CTP_HOME/conf/medium_dev.conf)
+        ;;
+      *)
+        (cd $WORKDIR/cubrid-testtools && HOME=$WORKDIR CTP/bin/ctp.sh $t)
+        ;;
+    esac
   done
 
   if [[ ":$TEST_SUITE:" =~ :(medium|sql): ]]; then


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1380

### Purpose

cubridci Docker 이미지를 두 가지 역할로 분리합니다:

1. **빌드 이미지** (`cubridci/cubridci:develop`) — `origin/develop` 유지, 변경 없음. CUBRID 엔진 빌드 파이프라인 사용.
2. **테스트 이미지** (`cubridci/cubridci:test_sql_medium`) — `origin/test_sqlmedium`에 신규 생성. SQL/Medium CTP 런타임 환경만 제공; 빌드 도구 제거.

이 분리로 테스트 환경 이미지 크기를 줄이고 역할을 명확히 합니다. 테스트 이미지는 사전 빌드된 CUBRID 아티팩트를 실행하는 런타임 환경이지, 빌드 환경이 아닙니다.

### Implementation

**Dockerfile** (`docker/ci/Dockerfile`):
- 베이스 OS: `centos:6` → `rockylinux/rockylinux:8.10`
- 제거: devtoolset-8, cmake, ninja, bison, 커스텀 ant, ccache, sclo-git212 (빌드 도구)
- 유지: gcc-c++ (CTP/shell 테스트), gdb, git, libxslt (JUnit 리포트), Java 8 (JDBC), 로케일, expect (자동화)
- 커스텀 bison/cmake 빌드 제거, dnf 기본 패키지 활용

**docker-entrypoint.sh**:
- 제거: `build`, `dist`, `jenkins-slave` (테스트 이미지 불필요)
- 유지: `checkout` (testtools/testcases 취득), `test` (CTP 실행)
- Hard-fail: `$CUBRID/bin/cubrid_rel` 부재 시 exit 1 (호출자가 사전 설치)
- 빈 인자: 사용법 출력 후 exit 1
- 그 외 인자 (`checkout`/`test` 외): `exec "$@"`로 외부 명령 전달
- Medium 스위트: cubrid-testtools의 `CTP/conf/medium_dev.conf` 참조로 변경 (in-place 패치 제거)

**검증 결과** (CUBRID 11.5.0.2191-5e12a29, K8s 마스터 노드 8 CPU/16Gi hostNetwork):
- **Medium**: 970/970 OK, 100% PASS (`linux_medium_64bit.xml` 162 KB)
- **SQL**: 17,393/17,393 OK, 100% PASS (`linux_sql_64bit.xml` 4.4 MB)

### Remarks

**변경 파일**: `docker/ci/Dockerfile`, `docker/ci/docker-entrypoint.sh` (2개)

**커밋 이력** (`cubridqa-1380` → `origin/test_sqlmedium`):
1. `76ebabb` split test image: rocky8 sql/medium runtime
2. `ac19373` use medium_dev.conf for medium suite
3. `9cc3afe` contain run_checkout cwd in subshells
4. `61b9c78` address review nits: 755 entrypoint, drop -l shell, relative medium_dev.conf

**Merge 정책**:
- 타겟: `test_sqlmedium` 브랜치만. **`origin/develop` 직접 머지 금지**.
- 빌드 이미지 (`cubridci/cubridci:develop`)는 Jenkinsfile/CircleCI 등 여러 시스템이 참조하므로 변경 없음.
- 테스트 이미지 (`:test_sql_medium`)와 빌드 이미지 (`:develop`) 태그 별도 관리.

**호출자 책임**: entrypoint.sh test 실행 전 CUBRID 바이너리 사전 설치 필요 (CircleCI `download-build-from-artifact` 단계에서 담당)
