### PR TITLE
[CUBRIDQA-1406] Collect CTP's own JUnit report instead of generating it via xsltproc

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -140,17 +140,15 @@ function report_test ()
     answerfile=${f/\/cases\//\/answers\/}
     answerfile=${answerfile/%.sql/.answer}
     resultfile=${f/%.sql/.result}
-    reportfile=${f/%.sql/.report} && echo "<failure message='unexpected result'><![CDATA[" > $reportfile
 
     ncount=$((ncount+1))
     printf "%115s\n" "($ncount/$nfailed)" | tr ' ' '-'
     testcases_case_url="$testcases_base_url/${casefile##*$testcases_root_dir/}"
     testcases_answer_url="$testcases_base_url/${answerfile##*$testcases_root_dir/}"
-    echo "** Testcase : ${casefile##*$testcases_root_dir/} - $testcases_case_url" | tee -a $reportfile
-    echo "** Expected : ${answerfile##*$testcases_root_dir/} - $testcases_answer_url" | tee -a $reportfile
+    echo "** Testcase : ${casefile##*$testcases_root_dir/} - $testcases_case_url"
+    echo "** Expected : ${answerfile##*$testcases_root_dir/} - $testcases_answer_url"
     echo "** Difference between Expected(-) and Actual(+) results:"
-    diff -ut $answerfile $resultfile | tee -a $reportfile
-    echo "]]></failure>" >> $reportfile
+    diff -ut $answerfile $resultfile || true
 
     if [ $max_print_failed -ne 0 -a $ncount -ge $max_print_failed ]; then
       break
@@ -164,33 +162,20 @@ function report_test ()
   echo ""
 
   if [ -n "$xml_output" ]; then
-    summary_xml_list=$(find $result_path -name summary.xml)
-    for f in $summary_xml_list; do
-      target=$(dirname ${f##*schedule_})
-      target=${target%_[0-9]*_*}
-      build_mode=$(cubrid_rel | grep -oe 'release\|debug')
-      cat << "_EOL" | xsltproc -o "$xml_output/${target}.xml" --stringparam target "${target}_${build_mode}" --stringparam casedir "${testcases_root_dir}/" - $f || true
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
- <xsl:output indent="yes" cdata-section-elements="failure"/>
- <xsl:template match="results">
-   <testsuites>
-     <testsuite name="{$target}" tests="{count(scenario)}" failures="{count(scenario/result[contains(.,'fail')])}">
-       <xsl:apply-templates select="scenario"/>
-     </testsuite>
-   </testsuites>
- </xsl:template>
- <xsl:template match="scenario">
-   <testcase classname="{$target}" name="{case}" file="cubrid-testcases/{case}" time="{elapsetime div 1000}">
-      <xsl:if test="result='fail'">
-        <xsl:variable name="testcase" select="case"/>
-        <xsl:variable name="report" select="concat($casedir, substring-before($testcase, '.sql'), '.report')"/>
-        <xsl:copy-of select="document($report)"/>
-      </xsl:if>
-   </testcase>
- </xsl:template>
-</xsl:stylesheet>
-_EOL
+    # CTP writes its own JUnit report (<os>_<type>_<bits>.xml, e.g. linux_sql_64bit.xml)
+    # next to summary.xml since cubrid-testtools#769; collect it for store_test_results.
+    ncopied=0
+    for f in $(find $result_path -name summary.xml); do
+      for x in "$(dirname $f)"/*.xml; do
+        [ -f "$x" ] || continue
+        [ "$(basename $x)" = "summary.xml" ] && continue
+        cp -f "$x" "$xml_output/" || true
+        ncopied=$((ncopied+1))
+      done
     done
+    if [ $ncopied -eq 0 ]; then
+      echo "[warn] no CTP JUnit XML found under $result_path (requires cubrid-testtools#769)"
+    fi
   fi
 
   if [ $nfailed -gt 0 ]; then

--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -80,23 +80,11 @@ function run_test ()
 
 function report_test ()
 {
-  local ncount=0
-  local max_print_failed=50
-
-  while getopts "x:n:" opt; do
-    case $opt in
-      x)
-        xml_output="$OPTARG"
-        [ ! -d "$xml_output" ] && mkdir -p "$xml_output"
-        ;;
-      n)
-        max_print_failed=$OPTARG
-        ;;
-      *)
-        ;;
-    esac
-  done
-  shift $(($OPTIND - 1))
+  if [ "$1" = "-x" ]; then
+    xml_output="$2"
+    mkdir -p "$xml_output"
+    shift 2
+  fi
 
   if [ $# -lt 1 ]; then
     return 1
@@ -110,9 +98,8 @@ function report_test ()
   #In case of testing nothing due to an error like failure to load a library.
   if [ `find $result_path -type f -name summary_info | wc -l` -eq 0 ]; then
      echo "Nothing is tested because of an error."
-     exit 1 
+     exit 1
   fi
-
 
   failed_list=$(find $result_path -name summary_info | xargs -n1 grep -hw nok | awk -F: '{print $1}')
   if [ -z "$failed_list" ]; then
@@ -120,50 +107,12 @@ function report_test ()
   else
     nfailed=$(echo "$failed_list" | wc -l)
   fi
-  echo ""
-  if [ $max_print_failed -ne 0 -a $nfailed -gt $max_print_failed ]; then
-    echo "** There are too many failed ($nfailed) Testcases on this test."
-    echo "** It will print details of only $max_print_failed failed Testcases."
-  elif [ $nfailed -gt 0 ]; then
-    echo "** There are $nfailed failed Testcases on this test."
-    echo "** It will print details of $nfailed failed Testcases."
-  fi
-  echo ""
-
-  testcases_root_dir="$WORKDIR/cubrid-testcases"
-  testcases_remote_url=$(cd $testcases_root_dir && git config --get remote.origin.url)
-  testcases_hash=$(cd $testcases_root_dir && git rev-parse HEAD)
-  testcases_base_url="${testcases_remote_url%.git}/blob/$testcases_hash"
-
-  for f in $failed_list; do
-    casefile=$f
-    answerfile=${f/\/cases\//\/answers\/}
-    answerfile=${answerfile/%.sql/.answer}
-    resultfile=${f/%.sql/.result}
-
-    ncount=$((ncount+1))
-    printf "%115s\n" "($ncount/$nfailed)" | tr ' ' '-'
-    testcases_case_url="$testcases_base_url/${casefile##*$testcases_root_dir/}"
-    testcases_answer_url="$testcases_base_url/${answerfile##*$testcases_root_dir/}"
-    echo "** Testcase : ${casefile##*$testcases_root_dir/} - $testcases_case_url"
-    echo "** Expected : ${answerfile##*$testcases_root_dir/} - $testcases_answer_url"
-    echo "** Difference between Expected(-) and Actual(+) results:"
-    diff -ut $answerfile $resultfile || true
-
-    if [ $max_print_failed -ne 0 -a $ncount -ge $max_print_failed ]; then
-      break
-    fi
-  done
-
-  if [ $max_print_failed -ne 0 -a $nfailed -gt $max_print_failed ]; then
-    printf "%115s\n" | tr ' ' '-'
-    echo "** More than $max_print_failed failed Testcases are omitted. (There are $nfailed failed Testcases on this test)"
-  fi
-  echo ""
 
   if [ -n "$xml_output" ]; then
     # CTP writes its own JUnit report (<os>_<type>_<bits>.xml, e.g. linux_sql_64bit.xml)
-    # next to summary.xml since cubrid-testtools#769; collect it for store_test_results.
+    # next to summary.xml since cubrid-testtools#769. Collect it for store_test_results;
+    # per-case failure details (query, diff, source links) live in its <failure> CDATA
+    # and are shown in the CircleCI 'Tests' tab, so they are no longer printed here.
     ncopied=0
     for f in $(find $result_path -name summary.xml); do
       for x in "$(dirname $f)"/*.xml; do
@@ -182,9 +131,9 @@ function report_test ()
     echo "** There are $nfailed failed Testcases on this test."
     echo "** All failed Testcases are listed below:"
     for f in $failed_list ; do
-      echo " - ${f##*$testcases_root_dir/}"
+      echo " - ${f##*$WORKDIR/cubrid-testcases/}"
     done
-    echo "** $nfailed cases are failed."
+    echo "** See the CircleCI 'Tests' tab for per-case queries, diffs and source links."
     exit $nfailed
   else
     echo "** All Tests are passed"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1406

## 무엇을 적용하나

CI 이미지(cubridci)의 entrypoint가 테스트 결과 XML을 **직접 만들던 일을 멈추고**, CTP가 이미 만들어 둔 결과 XML을 **그대로 가져다 제출**하도록 바꾼다. (CTP가 결과를 직접 만드는 변경은 cubrid-testtools#769)

함께, 실패 케이스를 콘솔에 길게 찍던 부분을 정리한다.

## 동작이 어떻게 변하나

**1. CI 'Tests' 탭 표시는 그대로다.**
제출되는 결과 파일의 이름·내용이 이전과 동일해서, 개발자가 보는 화면은 바뀌지 않는다. 단, 실패 케이스를 펼쳤을 때의 정보는 **더 풍부해진다** — 파일 전체 diff 대신 실패한 쿼리 원문 + 해당 부분 diff + 소스 GitHub 링크 (cubrid-testtools#769 덕분).

**2. CI 콘솔(job 로그)이 짧고 깔끔해진다.**
이전에는 실패 케이스마다 URL과 diff를 콘솔에 통째로 찍어, 대량 실패 시 로그가 수십만 자로 잘리곤 했다. 이제 콘솔에는 **실패한 케이스 목록과 "자세한 내용은 Tests 탭 참고" 안내만** 남는다. 실패 상세는 Tests 탭이 단일 출처가 된다.

**3. 빌드 결과(통과/실패) 판정은 이전과 똑같다.**
실패 개수만큼 종료 코드를 반환하는 동작, 테스트가 하나도 안 돈 경우 실패 처리하는 동작은 모두 유지된다.

## 적용 순서 (중요)

**cubrid-testtools#769을 먼저 머지한 뒤** 이 PR을 머지해야 한다.
순서가 바뀌면 — 즉 CTP가 아직 결과 XML을 안 만드는 상태에서 이 변경이 먼저 들어가면 — 가져갈 XML이 없어 CI 'Tests' 탭이 빈다.
- CircleCI: 빈 채로 통과 (빌드 자체는 정상).
- Jenkins(비-feature 브랜치): 결과 파일이 없으면 **빌드가 실패**할 수 있다.

이 상황은 job 로그의 `[warn] no CTP JUnit XML found ...` 메시지로 바로 알 수 있다.

## 확인한 것

로컬에서 4가지 상황(정상 실패 / 전체 통과 / 결과 XML 없음 / 테스트 미수행)을 점검했고, 실제 쿠버네티스 환경에서 수정된 entrypoint로 돌려 본 결과 — 제출된 XML이 CTP가 만든 원본과 완전히 동일하고, 불필요한 임시 파일이 생기지 않으며, 통과/실패 판정이 유지됨을 확인했다.

CircleCI(`config.yml`)와 Jenkins(`Jenkinsfile`) 양쪽 수집 경로를 점검해, 비-JUnit 파일(`summary.xml`)은 제출에서 제외되고 정식 결과 XML만 넘어가는 것도 확인했다.

## 이번 범위 밖

- 이미지에서 더는 쓰지 않는 `libxslt` 패키지 제거 — 별도 정리로 미룸.
