### PR TITLE
[CUBRIDQA-1439] add perl-core package installation in Dockerfile

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -20,6 +20,7 @@ RUN set -x \
                 ncurses-devel cmake ant flex sclo-git212 wget libxslt \
                 rpm-build libtool libtool-ltdl autoconf automake \
                 which ccache \
+                perl-core \
         && yum clean all -y \
         && rm -rf /var/cache/yum
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1439

- To compile openssl 3.X, the perl-core package is required.