### PR TITLE
[CUBRIDQA-1261] CI: retry test_shell checkout with backoff and fail fast

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -28,17 +28,42 @@ clone_repository() {
   local repo=$1
   local branch=$2
   local url="https://github.com/CUBRID/$repo.git"
-  
+  local dir="$WORKDIR/$repo"
+
   debug "clone_repository $repo $branch $url" "$LINENO"
-  if [ ! -d "$WORKDIR/$repo" ]; then
-    git -c fetch.parallel=0 -c core.compression=9 clone -q --depth 1 --branch $branch --single-branch --no-tags $url $WORKDIR/$repo
-  elif [ -d "$WORKDIR/$repo" ]; then
-    ( cd $WORKDIR/$repo && git fetch --depth 1 origin $branch && git reset --hard origin/$branch && git clean -df )
-  else
-    debug "Cannot find .git from $WORKDIR/$repo directory!" "$LINENO"
-    exit 1
-  fi
-  if [ "$DEBUG" = true ]; then debug "$(ls -la $WORKDIR/$repo)" "$LINENO"; fi
+
+  # Bring the pre-seeded checkout (a blob:none partial + sparse clone that the pod
+  # overlay-mounts) to $branch. reset --hard lazily fetches the missing blobs from
+  # the promisor remote; under the 50-way shell fan-out GitHub can transiently
+  # throttle that fetch (seen as "Empty reply from server" / "Authentication
+  # failed" on a few nodes). Retry with backoff, and if it still fails, exit
+  # non-zero so we never run tests on an incomplete working tree.
+  local i ok=
+  for i in 1 2 3 4 5; do
+    if [ -d "$dir/.git" ]; then
+      ( cd "$dir" \
+        && git -c fetch.parallel=0 fetch --depth 1 --no-tags origin "$branch" \
+        && git reset --hard "origin/$branch" \
+        && git clean -df ) && { ok=1; break; }
+    else
+      git -c fetch.parallel=0 -c core.compression=9 clone -q --depth 1 --branch "$branch" \
+          --single-branch --no-tags "$url" "$dir" && { ok=1; break; }
+    fi
+    echo "[warn] checkout of $repo ($branch) attempt $i/5 failed; retrying in $((i * 10))s" >&2
+    sleep $((i * 10))
+  done
+  [ -n "$ok" ] || { echo "** ERROR: checkout of $repo ($branch) failed after retries" >&2; exit 1; }
+
+  # Sanity check: a completed clone/reset leaves HEAD at the branch tip.
+  local head
+  head=$(git -C "$dir" rev-parse --verify HEAD 2>/dev/null) \
+    || { echo "** ERROR: $repo has no valid HEAD after checkout ($branch)" >&2; exit 1; }
+
+  # Always report what was actually checked out (branch + commit + subject).
+  echo "[checkout] $repo @ $branch -> $head $(git -C "$dir" log -1 --pretty=format:'%s' 2>/dev/null)"
+
+  if [ "$DEBUG" = true ]; then debug "$(ls -la "$dir")" "$LINENO"; fi
+  return 0
 }
 
 # Git configuration and repository cloning


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1261>

### Purpose

shell 테스트(`cubridci/cubridci:test_shell`)에서 병렬 노드 하나가 테스트 케이스와 무관하게 실패하는 일이 있었습니다(job 139249, node 42). 원인은 엔진/TC가 아니라 `/entrypoint.sh checkout`의 private TC 체크아웃이었습니다.

노드 pre-seed repo는 `--filter=blob:none`(partial=promisor) + sparse-checkout로 두고 pod가 overlay 마운트합니다. `git reset --hard`가 필요한 blob을 promisor remote에서 lazy fetch하는데, **50-way 동시 fan-out에서 GitHub가 일시적으로 throttle**하면 그 fetch가 `Empty reply from server` / `Authentication failed`로 튕깁니다(50개 중 2개 노드에서만 발생, 48개는 성공 — 일시적 부하의 전형적 신호). 그런데 checkout이 이를 중단하지 않고 진행해서, 불완전한 트리 위에서 테스트가 돌아 7개 TC가 거짓 실패했습니다.

shell pod 안에서 직접 검증한 결과, 지금의 `url.insteadOf` 인증은 promisor lazy fetch도 **정상 인증**합니다(git 2.43.7). 즉 인증 방식 문제가 아니라 **일시적 throttle + 실패 미전파**가 원인입니다.

### Implementation

`clone_repository`를 수정했습니다(인증 방식은 그대로 둠).

- **재사용 유지**: 노드가 pre-seed한 `blob:none` partial + sparse 체크아웃을 그대로 재사용합니다(fresh clone 안 함). overlay 마운트 설계에 맞고, 불필요한 재다운로드/부하를 만들지 않습니다.
- **retry + backoff**: `fetch`/`reset --hard`를 최대 5회, 10·20·30·40초 backoff로 재시도해 일시적 throttle를 넘깁니다.
- **fail-fast**: 재시도까지 실패하면 `exit` 로 job을 즉시 실패시켜, 불완전한 트리에서 테스트가 도는 일을 막습니다(기존엔 함수 끝의 debug 문장 때문에 실패가 성공으로 반환됐습니다).

### Remarks

- shell pod에서 실측 검증: (1) 재사용+reset로 오래된 develop→최신 tip 전환 시 2178개 파일을 lazy fetch하며 성공(exit 0), (2) 무인증일 때 재시도 후 non-zero로 중단(fail-fast) 확인.
- 인증은 건드리지 않았습니다. `url.insteadOf`(현행)가 lazy fetch까지 인증함을 pod에서 확인했고, token-URL/HTTP 헤더 방식도 모두 동작했습니다 — 즉 원래 실패는 인증 설정이 아니라 동시성 throttle이었습니다.
- 동일 파일이 `develop`(build/sql/medium 이미지)에도 쓰이므로, 필요하면 같은 변경을 그쪽에도 반영해야 합니다.
- `bug_bts_14305`(node 43) 1건은 checkout 오류 없이 실패했고 로컬/이전 실행에서는 성공, Insights에서도 flaky — async killtran 관련 flaky TC로 별도 점검이 필요합니다(이 PR 범위 밖).
