### PR TITLE
[CUBRIDQA-1261] CI: harden testcases checkout on develop (retry, fail-fast, log branch)

### DIFF
--- a/docker/ci/docker-entrypoint.sh
+++ b/docker/ci/docker-entrypoint.sh
@@ -1,27 +1,39 @@
 #!/bin/bash -le
 
+# Check out a repo at a branch: clone if absent, else fetch+reset+clean.
+# Retry transient network failures and exit non-zero if it never succeeds,
+# then log the resolved branch + commit so the CI log shows what ran.
+function checkout_repo ()
+{
+  local repo=$1
+  local branch=$2
+  local url="https://github.com/CUBRID/$repo.git"
+  local dir="$WORKDIR/$repo"
+  local i ok=
+  for i in 1 2 3 4 5; do
+    if [ -d "$dir/.git" ]; then
+      ( cd "$dir" \
+        && git fetch -q --depth 1 origin "$branch" \
+        && git reset --hard FETCH_HEAD \
+        && git clean -df ) && { ok=1; break; }
+    else
+      git clone -q --depth 1 --branch "$branch" "$url" "$dir" && { ok=1; break; }
+    fi
+    echo "[warn] checkout of $repo ($branch) attempt $i/5 failed; retrying in $((i * 10))s" >&2
+    sleep $((i * 10))
+  done
+  [ -n "$ok" ] || { echo "** ERROR: checkout of $repo ($branch) failed after retries" >&2; exit 1; }
+
+  local head
+  head=$(git -C "$dir" rev-parse --verify HEAD 2>/dev/null) \
+    || { echo "** ERROR: $repo has no valid HEAD after checkout ($branch)" >&2; exit 1; }
+  echo "[checkout] $repo @ $branch -> $head $(git -C "$dir" log -1 --pretty=format:'%s' 2>/dev/null)"
+}
+
 function run_checkout ()
 {
-  if [ ! -d $WORKDIR/cubrid-testtools ]; then
-    git clone -q --depth 1 --branch $BRANCH_TESTTOOLS https://github.com/CUBRID/cubrid-testtools $WORKDIR/cubrid-testtools
-  elif [ -d $WORKDIR/cubrid-testtools/.git ]; then
-    (cd $WORKDIR/cubrid-testtools && git clean -df)
-  else
-    echo "Cannot find .git from $WORKDIR/cubrid-testtools directory!"
-    return 1
-  fi
-  if [ ! -d $WORKDIR/cubrid-testcases ]; then
-    git clone -q --depth 1 --branch $BRANCH_TESTCASES https://github.com/CUBRID/cubrid-testcases $WORKDIR/cubrid-testcases
-  elif [ -d $WORKDIR/cubrid-testcases/.git ]; then
-    cd $WORKDIR/cubrid-testcases && \
-    git fetch -q --depth 1 origin $BRANCH_TESTCASES && \
-    git reset --hard FETCH_HEAD && \
-    git clean -df
-  else
-    echo "Cannot find .git from $WORKDIR/cubrid-testcases directory!"
-    return 1
-  fi
-
+  checkout_repo cubrid-testtools "$BRANCH_TESTTOOLS"
+  checkout_repo cubrid-testcases "$BRANCH_TESTCASES"
 }
 
 function run_build ()


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1261>

### Purpose

`:develop` 이미지(build/sql/medium 테스트에서 사용)의 `/entrypoint.sh checkout`은 `cubrid-testtools`·`cubrid-testcases`를 clone/reset하면서 (1) 재시도가 없고, (2) 실패를 명확히 전파하지 않으며(함수 `return 1`은 미존재 `.git`에만, git 실패는 `-e` 의존), (3) **어느 브랜치/커밋으로 체크아웃했는지 로그에 남기지 않았습니다.** 네트워크 일시 장애 시 stale/불완전 트리 위에서 테스트가 조용히 돌 수 있고, 실패 분석 시 "어느 TC로 돌았는지" 확인이 어렵습니다.

### Implementation

`run_checkout`을 공용 헬퍼 `checkout_repo`로 재작성했습니다(두 repo 모두 사용):

- **retry + backoff**: `fetch`/`clone`을 최대 5회, 10·20·30·40초 backoff로 재시도 → 일시적 네트워크 실패를 넘김.
- **fail-fast**: 재시도까지 실패하면 `exit` 로 job을 즉시 실패시켜, 불완전한 트리에서 테스트가 도는 것을 막음.
- **체크아웃 로그**: 성공 시 항상 `[checkout] <repo> @ <branch> -> <sha> <제목>` 한 줄을 출력해, 어떤 브랜치/커밋으로 체크아웃했는지 CI 로그에 남김.

`cubrid-testcases` 브랜치는 `$BRANCH_TESTCASES`로 그대로 결정됩니다(로직 불변). 인증이 필요 없는 public repo라 토큰 관련 변경은 없습니다.

### Remarks

- **동작 변화 1건**: `cubrid-testtools` 재사용 경로가 기존 `git clean -df`(업데이트 안 함) → **`fetch + reset --hard + clean`**(브랜치 tip으로 갱신)으로 바뀝니다. `cubrid-testcases` 경로 및 `test_sqlmedium` 브랜치와 동일하게 맞춘 것으로, stale testtools 재사용을 막습니다.
- 이 변경은 `develop` 브랜치를 대상으로 하여 `cubridci/cubridci:develop` 이미지가 재빌드되면 적용됩니다. shell(`test_shell`)·`test_sqlmedium` 브랜치에도 같은 취지의 별도 PR이 있습니다.
- 로컬에서 헬퍼의 clone/재사용 경로가 `[checkout]` 라인을 정상 출력함을 확인했습니다.
