### PR TITLE
[CUBRIDQA-1261] Pre-install circleci-tests-plugin-cli in the test_shell image

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -37,6 +37,17 @@ RUN localedef -f UTF-8 -i ko_KR ko_KR.UTF-8 \
  && localedef -f UTF-8 -i en_US en_US.UTF-8
 ENV LANG=en_US.UTF-8
 
+# Pre-install the CircleCI tests plugin at the exact path the task agent expects,
+# so `circleci tests run` reuses it instead of downloading it from S3 during the
+# job (that download times out under 50-way fan-out on a slow WAN and fails the
+# split step). If CircleCI bumps the plugin version, the agent ignores this stale
+# cache and falls back to downloading, i.e. the behavior before this change.
+ARG TESTS_PLUGIN_VERSION=1.0.13141-073b78b
+RUN mkdir -p /tmp/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64 && \
+    wget -q -O /tmp/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64/circleci-tests-plugin-cli \
+        "https://circleci-binary-releases.s3.amazonaws.com/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64/circleci-tests-plugin-cli" && \
+    chmod 755 /tmp/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64/circleci-tests-plugin-cli
+
 #circleci env
 ENV TEST_REPORT=/tmp/tests
 ENV BASELINE none


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1261>

### Purpose

사무실 인터넷 회선 저하(패킷 손실)로 test_shell 잡의 split 단계에서 task agent가 매번 S3에서 받아오는 `circleci-tests-plugin-cli`(약 11MB) 다운로드가 `context deadline exceeded`로 실패하고, 4회 재시도 후 노드가 실패 처리되는 문제가 반복되고 있습니다.

### Implementation

test_shell 이미지에 `circleci-tests-plugin-cli` 바이너리를 task agent가 찾는 경로(`/tmp/circleci-tests-plugin-cli/<version>/linux/amd64/`)에 미리 설치해 둡니다. 적용 후에는 잡 실행 시 agent가 이미지에 들어있는 바이너리를 재사용하므로 split 단계에서 S3 다운로드 없이 바로 진행되고, 회선 상태와 무관하게 split이 성공합니다.

### Remarks

- 회선 복구 전까지의 임시 조치입니다. plugin 버전(`1.0.13141-073b78b`)은 CircleCI가 API로 내려주는 값이라, CircleCI 쪽에서 버전을 올리면 이미지에 넣어둔 캐시는 무시되고 기존처럼 다운로드로 동작합니다(현재보다 나빠지지 않음). 그 경우 Dockerfile의 `TESTS_PLUGIN_VERSION`만 올려서 이미지를 다시 빌드하면 됩니다.
- 검증: 이 브랜치로 이미지 빌드·push 후 test_shell 잡에서 split 단계가 "Installing circleci-tests-plugin-cli plugin" 다운로드 없이 통과하는지 확인.
