### PR TITLE
[CUBRIDQA-1261] Fix pre-installed tests plugin: decompress gzip and pin sha256

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -42,10 +42,16 @@ ENV LANG=en_US.UTF-8
 # job (that download times out under 50-way fan-out on a slow WAN and fails the
 # split step). If CircleCI bumps the plugin version, the agent ignores this stale
 # cache and falls back to downloading, i.e. the behavior before this change.
+# The S3 object is stored with Content-Encoding: gzip, so wget saves gzip bytes;
+# decompress before install and pin the sha256 the agent verifies at runtime —
+# a wrong hash must fail the image build, not the CI job.
 ARG TESTS_PLUGIN_VERSION=1.0.13141-073b78b
+ARG TESTS_PLUGIN_SHA256=f335d9672fee958006123ee91ba03a99f30110c6c66db11fc57b845a28414848
 RUN mkdir -p /tmp/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64 && \
-    wget -q -O /tmp/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64/circleci-tests-plugin-cli \
-        "https://circleci-binary-releases.s3.amazonaws.com/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64/circleci-tests-plugin-cli" && \
+    wget -q -O - \
+        "https://circleci-binary-releases.s3.amazonaws.com/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64/circleci-tests-plugin-cli" \
+        | gzip -d > /tmp/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64/circleci-tests-plugin-cli && \
+    echo "${TESTS_PLUGIN_SHA256}  /tmp/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64/circleci-tests-plugin-cli" | sha256sum -c && \
     chmod 755 /tmp/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64/circleci-tests-plugin-cli
 
 #circleci env


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1261>

### Purpose

#101로 이미지에 미리 넣은 `circleci-tests-plugin-cli`가 잡 실행 시 agent의 checksum 검증에서 실패해 test_shell split이 계속 실패하고 있습니다 (`Failed to verify checksum: expected f335d967..., got 9606b95a...`).

원인: 해당 S3 오브젝트는 `Content-Encoding: gzip`으로 저장돼 있어 wget이 **gzip 압축 바이트를 그대로 파일로 저장**합니다(9606b95a...). 반면 agent(Go HTTP client)는 자동 압축 해제된 원본 바이너리(f335d967...)를 기대합니다. 즉 이미지에 압축된 채로 구워진 것이 원인입니다.

한편 이번 실패 로그는 **agent가 경로에 파일이 있으면 다운로드 없이 그 파일을 검증·재사용한다는 것을 실증**했습니다 — pre-install 방식 자체는 유효합니다.

### Implementation

- 다운로드 스트림을 `gzip -d`로 풀어서 저장하도록 수정 (압축 해제본 21,969,178 bytes ELF).
- agent가 런타임에 검증하는 sha256(`f335d967...`)을 `TESTS_PLUGIN_SHA256` ARG로 고정하고 **빌드 시점에 `sha256sum -c`로 검증** — 잘못된 바이너리는 CI 잡이 아니라 이미지 빌드에서 실패하도록 했습니다.
- 적용 후: test_shell 잡의 split 단계에서 checksum 검증을 통과해 S3 다운로드 없이 바로 진행됩니다.

### Remarks

- 로컬에서 동일 명령 시뮬레이션 완료: checksum OK + `circleci-tests-plugin-cli version: 1.0.13141-073b78b` 실행 확인.
- CircleCI가 plugin 버전을 올리면 `TESTS_PLUGIN_VERSION`/`TESTS_PLUGIN_SHA256` 두 ARG를 갱신해 재빌드하면 됩니다. 새 기대 hash는 버전 업데이트 후 실패 로그의 expected 값 또는 `wget -qO- <URL> | gzip -d | sha256sum`으로 확인합니다.
- 검증: 이미지 재빌드·push 후 test_shell 재실행 → split 단계가 "Installing" 후 에러 없이 통과하는지 확인.
