### PR TITLE
[CUBRIDQA-1261] Bump pre-installed tests plugin to 1.0.13506-242eb49

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -45,8 +45,8 @@ ENV LANG=en_US.UTF-8
 # The S3 object is stored with Content-Encoding: gzip, so wget saves gzip bytes;
 # decompress before install and pin the sha256 the agent verifies at runtime —
 # a wrong hash must fail the image build, not the CI job.
-ARG TESTS_PLUGIN_VERSION=1.0.13141-073b78b
-ARG TESTS_PLUGIN_SHA256=f335d9672fee958006123ee91ba03a99f30110c6c66db11fc57b845a28414848
+ARG TESTS_PLUGIN_VERSION=1.0.13506-242eb49
+ARG TESTS_PLUGIN_SHA256=d9d5aeb58f6e54b3990c9dae079d7812de555d33980d40eacb71061c3b6ec8cf
 RUN mkdir -p /tmp/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64 && \
     wget -q -O - \
         "https://circleci-binary-releases.s3.amazonaws.com/circleci-tests-plugin-cli/${TESTS_PLUGIN_VERSION}/linux/amd64/circleci-tests-plugin-cli" \


### PR DESCRIPTION
jira: http://jira.cubrid.org/browse/CUBRIDQA-1261

### Purpose

CircleCI가 2026-08-03에 tests plugin 새 버전(`1.0.13506-242eb49`)을 릴리즈하면서, 이미지에 pre-install해 둔 구버전(`1.0.13141-073b78b`) 캐시가 무효화되었습니다. agent가 새 버전을 S3에서 다시 내려받으려다 회선 제약으로 타임아웃되어 test_shell 전 노드에서 split이 실패하는 문제가 재발했습니다(#101, #102 도입 당시 예고했던 버전 범프 리스크).

```
Error: Failed to download and install circleci-tests-plugin-cli plugin: ... context deadline exceeded
[error] test split failed after 4 attempts; failing node to avoid silently skipping tests
```

### Implementation

- pre-install하는 plugin 버전을 `1.0.13506-242eb49`로 올리고, sha256도 새 바이너리의 값으로 교체했습니다.
- sha256은 로컬에서 실제 다운로드·gzip 해제 후 검증한 값입니다 (바이너리 실행 확인: `version: 1.0.13506-242eb49 Built: 2026-08-03`).
- 이미지 반영 후에는 잡 시작 시 다운로드 없이 pre-install된 plugin을 재사용하여 test_shell이 정상 동작합니다.

### Remarks

- CircleCI가 다음 버전을 릴리즈하면 같은 문제가 또 재발합니다. 근본 해결은 plugin 의존 제거(`circleci tests split` 전환, CUBRIDQA-1471 1단계)이며 이 PR은 그때까지의 임시조치 갱신입니다.
- 이미지 push와 진행 중인 잡 사이에 race가 있으므로, push 완료 후 시작된 잡부터 적용됩니다.
